### PR TITLE
Default keys from settings

### DIFF
--- a/cmsplugin_contact/admin.py
+++ b/cmsplugin_contact/admin.py
@@ -15,8 +15,10 @@ class KeyField(CharField):
 class ContactAdminForm(ModelForm):
     akismet_api_key = KeyField(max_length=255, label=_("Akismet API Key"), help_text=_('Get a Wordpress Key from http://akismet.com/'))
 
-    recaptcha_public_key = KeyField(max_length=255, label=_("ReCAPTCHA Public Key"), help_text=_('Get this from http://www.google.com/recaptcha'))
-    recaptcha_private_key = KeyField(max_length=255, label=_("ReCAPTCHA Private Key"), help_text=_('Get this from http://www.google.com/recaptcha'))
+    recaptcha_public_key = getattr(settings, "RECAPTCHA_PUBLIC_KEY", \
+                           KeyField(max_length=255, label=_("ReCAPTCHA Public Key"), help_text=_('Get this from http://www.google.com/recaptcha')))
+    recaptcha_private_key = getattr(settings, "RECAPTCHA_PRIVATE_KEY", \
+                           KeyField(max_length=255, label=_("ReCAPTCHA Private Key"), help_text=_('Get this from http://www.google.com/recaptcha')))
     
     class Meta:
     	model = Contact
@@ -55,8 +57,10 @@ class ContactAdminForm(ModelForm):
     	except ImportError:
     		self._add_error('spam_protection_method', _('ReCAPTCHA library is not installed. Use "easy_install recaptcha-client" or "pip install recaptcha-client".'))
     		
-    	public_key = self.cleaned_data['recaptcha_public_key']
-    	private_key = self.cleaned_data['recaptcha_private_key']
+        public_key = getattr(settings, "RECAPTCHA_PUBLIC_KEY", \
+                     self.cleaned_data['recaptcha_public_key'])
+        private_key = getattr(settings, "RECAPTCHA_PRIVATE_KEY", \
+                      self.cleaned_data['recaptcha_private_key'])
     	
     	if not public_key:
     		self._add_error('recaptcha_public_key', Field.default_error_messages['required'])

--- a/cmsplugin_contact/cms_plugins.py
+++ b/cmsplugin_contact/cms_plugins.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
@@ -29,8 +30,10 @@ class ContactPlugin(CMSPluginBase):
             AkismetContactForm.aksimet_api_key = instance.aksimet_api_key
             FormClass = AkismetContactForm
         elif instance.get_spam_protection_method_display() == 'ReCAPTCHA':
-            RecaptchaContactForm.recaptcha_public_key = instance.recaptcha_public_key
-            RecaptchaContactForm.recaptcha_private_key = instance.recaptcha_private_key
+            RecaptchaContactForm.recaptcha_public_key = getattr(settings, "RECAPTCHA_PUBLIC_KEY", \
+                                                        instance.recaptcha_public_key)
+            RecaptchaContactForm.recaptcha_private_key = getattr(settings, "RECAPTCHA_PRIVATE_KEY", \
+                                                         instance.recaptcha_private_key)
             RecaptchaContactForm.recaptcha_theme = instance.recaptcha_theme
             FormClass = RecaptchaContactForm
         else:


### PR DESCRIPTION
Hey,
great module - nicely thought out.  I was 2 hours into mod'ing django-contact-form into a plugin when I thought... someone's done this before...  this one is much better!

One issue I had was with asking for the recaptcha keys on the contact plugin admin form :
1. if the site has several contact forms (say for different depts. or people), it's a pain, and error prone to keep those in sync.
2. if my client wants to add a contact form, i don't want him/her to have to think about keys (and get them wrong, and get frustrated... you know ;-)
3. Most compelling:  since those keys are tied to a domain, they won't work in all environments (dev, stage, prod.)

I do like your idea - it makes it very simple to install and use in basic cases (one form, global key), but thought it would be good if one could optionally configure the keys in the settings file.  The idea would be that if the settings are found, the keys are left off the form and are not stored in the model.

This pull gets most of the way there.  I choose the settings names to match those used by glamkit-spamstop.  Seems to work.

I've got one issue (the fields are still showing up,  but optional, not sure why), and could apply same idea to Akismet, but wanted to check with you if you think this is worthwhile and if their might be a better approach before I spend more time on it.

thanks again for a really great, flexible plugin.
P.S. I'm new to github - this is my first pull request - hope this is the appropriate method, take it easy on me if I'm out in left field ;-)
