### PR TITLE
Documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ Django Apps
 -----------
 
 `glamkit-stopspam <http://github.com/maccesch/glamkit-stopspam>`_ provides nice spam protection support.
+You have to use the latest version from https://github.com/glamkit/glamkit-stopspam/ as the version in PyPI is outdated.
 
 Python Libs
 -----------


### PR DESCRIPTION
 stopspam version in PyPI is outdated, so it is required the latest version from github
