### PR TITLE
mail subject : using property instead of a hardwritten string

### DIFF
--- a/cmsplugin_contact/cms_plugins.py
+++ b/cmsplugin_contact/cms_plugins.py
@@ -18,6 +18,7 @@ class ContactPlugin(CMSPluginBase):
     render_template = "cmsplugin_contact/contact.html"
     form = ContactAdminForm
     contact_form = ContactForm
+    subject_template = "cmsplugin_contact/subject.txt"
     email_template = "cmsplugin_contact/email.txt"
     
     fieldsets = (
@@ -96,7 +97,7 @@ class ContactPlugin(CMSPluginBase):
         if not subject:
             subject = _('No subject')
         email_message = EmailMessage(
-            render_to_string("cmsplugin_contact/subject.txt", {
+            render_to_string(self.subject_template, {
                 'subject': subject,
             }),
             render_to_string(self.email_template, {


### PR DESCRIPTION
I had to override the `send` method to change the default subject template in my subclassed `ContactPlugin`

Using a class property will make the code more usable and clean.
