### PR TITLE
this needs to be unicode in order for translation to ocurr, not str

### DIFF
--- a/cmsplugin_contact/nospam/widgets.py
+++ b/cmsplugin_contact/nospam/widgets.py
@@ -27,5 +27,5 @@ class RecaptchaChallenge(forms.Widget):
 class HoneypotWidget(forms.CheckboxInput):
     is_hidden = True
     def render(self, *args, **kwargs):
-        wrapper_html = '<div style="display: none;"><label for="id_accept_terms">%s</label>%%s</div>'%(_('Are you a robot?'))
+        wrapper_html = u'<div style="display: none;"><label for="id_accept_terms">%s</label>%%s</div>' % (_('Are you a robot?'))
         return mark_safe(wrapper_html % super(HoneypotWidget, self).render(*args, **kwargs))


### PR DESCRIPTION
I was getting this rendered:

`<label for="id_accept_terms"><django.utils.functional.__proxy__ object at 0x10d777750></label>`

also, maybe this should be using `ugettext` instead of `ugettext_lazy`, since this happens at render time, not on the setup phase
