### PR TITLE
Include TextEditorWidget from djangocms-text-ckeditor package

### DIFF
--- a/cmsplugin_contact/cms_plugins.py
+++ b/cmsplugin_contact/cms_plugins.py
@@ -40,6 +40,9 @@ class ContactPlugin(CMSPluginBase):
         if USE_TINYMCE and "tinymce" in settings.INSTALLED_APPS:
             from cms.plugins.text.widgets.tinymce_widget import TinyMCEEditor
             return TinyMCEEditor(installed_plugins=plugins)
+        elif "djangocms_text_ckeditor" in settings.INSTALLED_APPS:
+            from djangocms_text_ckeditor.widgets import TextEditorWidget
+            return TextEditorWidget(installed_plugins=plugins)
         else:
             return WYMEditor(installed_plugins=plugins)
 


### PR DESCRIPTION
When you change default text editor in django-cms to djangocms-text-ckeditor then you have problem, django is searching for templates of text plugin, so I create this small modification and I hope you can use this editor now.
