### PR TITLE
Use 'ugettext' instead of 'ugettext_lazy' in 'cmsplugin_contact.nospam.widgets.HoneypotWidget.render()'

### DIFF
--- a/cmsplugin_contact/nospam/widgets.py
+++ b/cmsplugin_contact/nospam/widgets.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _, get_language
+from django.utils.translation import ugettext as _, get_language
 from django.utils.safestring import mark_safe
 
 


### PR DESCRIPTION
When rendering `HoneypotWidget` language is already active and it is not necessary to use `ugettext_lazy` as it returns object instance. Plus, string operator `%` will insert into string value of `repr()` instead translated text. It results in incorrect HTML.
