### PR TITLE
django-cms 3.0 compatibility

### DIFF
--- a/cmsplugin_contact/cms_plugins.py
+++ b/cmsplugin_contact/cms_plugins.py
@@ -3,12 +3,15 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from django.forms.fields import CharField
 from django.core.mail import EmailMessage
-from django.template.loader import render_to_string
+from django.template.loader import render_to_string, find_template, TemplateDoesNotExist
 
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-from cms.plugins.text.settings import USE_TINYMCE
-from cms.plugins.text.widgets.wymeditor_widget import WYMEditor
+try:
+    from cms.plugins.text.settings import USE_TINYMCE
+except ImportError:
+    USE_TINYMCE = False
+
 from models import Contact
 from forms import ContactForm, AkismetContactForm, RecaptchaContactForm, HoneyPotContactForm
 from admin import ContactAdminForm
@@ -49,6 +52,7 @@ class ContactPlugin(CMSPluginBase):
             from djangocms_text_ckeditor.widgets import TextEditorWidget
             return TextEditorWidget(installed_plugins=plugins)
         else:
+            from cms.plugins.text.widgets.wymeditor_widget import WYMEditor
             return WYMEditor(installed_plugins=plugins)
 
     def get_form_class(self, request, plugins):
@@ -142,10 +146,18 @@ class ContactPlugin(CMSPluginBase):
         return context
 
     def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):
+        template = "admin/cms/page/plugin/change_form.html"  # django-cms 3.0
+        try:
+            find_template(template)
+        except TemplateDoesNotExist:
+            # django-cms < 3.0
+            template = "admin/cms/page/plugin_change_form.html"
+
         context.update({
             'spam_protection_method': obj.spam_protection_method if obj else 0,
             'recaptcha_settings': hasattr(settings, "RECAPTCHA_PUBLIC_KEY"),
             'akismet_settings': hasattr(settings, "AKISMET_API_KEY"),
+            'parent_template': template
         })
 
         return super(ContactPlugin, self).render_change_form(request, context, add, change, form_url, obj)

--- a/cmsplugin_contact/templates/cmsplugin_contact/admin/plugin_change_form.html
+++ b/cmsplugin_contact/templates/cmsplugin_contact/admin/plugin_change_form.html
@@ -1,4 +1,4 @@
-{% extends "admin/cms/page/plugin_change_form.html" %}
+{% extends parent_template %}
 
 {% block extrahead %}{{ block.super }}
 <script type="text/javascript">


### PR DESCRIPTION
I've needed this to use the plugin with dj-cms trunk.

So here are the changes in case you want to merge them (they are supposed not to break the compatibility with the 2.x ;) ):
- do not fail if cms.plugin.text does not exist
- use new plugin/change_form.html template, and fallback to old if
  it does not exist

Thanks!

Yohan
