### PR TITLE
Contact plugin should not be cached

### DIFF
--- a/cmsplugin_contact/cms_plugins.py
+++ b/cmsplugin_contact/cms_plugins.py
@@ -31,6 +31,9 @@ class ContactPlugin(CMSPluginBase):
     subject_template = "cmsplugin_contact/subject.txt"
     email_template = "cmsplugin_contact/email.txt"
 
+    cache = False  # this is a form, should always be reloaded.
+    # (New in django-cms 3.0c, all plugins are cached through django cache)
+
     fieldsets = (
         (None, {
             'fields': ('form_name', 'form_layout', 'site_email', 'thanks', 'submit'),


### PR DESCRIPTION
Django CMS 3.0c introduces caching for plugins http://django-cms.readthedocs.org/en/latest/advanced/caching.html#plugins

This means that the render method isn't called, with unexpected effects in particular if the first submission did not work (eg. an error).
