### PR TITLE
Fixed migration 0007 to work with south 1.0

### DIFF
--- a/cmsplugin_contact/migrations/0007_add_url_field.py
+++ b/cmsplugin_contact/migrations/0007_add_url_field.py
@@ -9,7 +9,7 @@ class Migration(SchemaMigration):
 
     def forwards(self, orm):
         db.add_column(u'cmsplugin_contact_contact', 'redirect_url',
-                      self.gf('django.db.models.fields.URLField')(blank=True),
+                      self.gf('django.db.models.fields.URLField')(blank=True, default=''),
                       keep_default=False)
 
     def backwards(self, orm):


### PR DESCRIPTION
Added a default value to the new redirect_url column. This migration will not run on south 1.0 when the default value is omitted. keep_default is a legacy argument. which is no long used in south 1.0.

I did not test the other migrations, this was the one that was bugging me.
